### PR TITLE
Add web proxy support.

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv/CommonApplication.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv/CommonApplication.java
@@ -7,6 +7,7 @@ import androidx.multidex.MultiDex;
 import com.jakewharton.disklrucache.DiskLruCache;
 import com.liskovsoft.sharedutils.helpers.Helpers;
 import com.liskovsoft.sharedutils.mylogger.Log;
+import com.liskovsoft.smartyoutubetv.misc.ProxyManager;
 import com.liskovsoft.smartyoutubetv.prefs.SmartPreferences;
 import com.squareup.otto.Bus;
 import com.squareup.otto.ThreadEnforcer;
@@ -26,6 +27,9 @@ public class CommonApplication extends Application {
 
         sSmartPreferences = SmartPreferences.instance(this);
         sCache = createDiskLruCache();
+
+        ProxyManager proxyManager = new ProxyManager(this);
+        proxyManager.configureSystemProxy();
     }
 
     private DiskLruCache createDiskLruCache() {

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv/misc/ProxyManager.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv/misc/ProxyManager.java
@@ -1,0 +1,284 @@
+package com.liskovsoft.smartyoutubetv.misc;
+
+import com.liskovsoft.sharedutils.helpers.MessageHelpers;
+import com.liskovsoft.sharedutils.mylogger.Log;
+import com.liskovsoft.smartyoutubetv.common.BuildConfig;
+import com.liskovsoft.smartyoutubetv.common.R;
+import com.liskovsoft.smartyoutubetv.prefs.SmartPreferences;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.Intent;
+import android.net.ProxyInfo;
+import android.os.Build;
+import android.os.Parcelable;
+import android.util.ArrayMap;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import androidx.annotation.RequiresApi;
+
+/**
+ * Manages web proxy settings, to enable web view and http client using web proxy.
+ * This implementation is based on the discussion here:
+ * https://stackoverflow.com/questions/4488338/webview-android-proxy
+ *
+ * Note that the implementation uses non-public Android API that subject to
+ * uninformed change in the future.
+ *
+ * DONE: Support SOCKS proxy
+ * TODO: Support API level 14 ~ 18
+ * TODO: Support exclusion list (?)
+ * TODO: Support PAC (Proxy Auto-Configuration)
+ */
+public class ProxyManager {
+    public static final String TAG = ProxyManager.class.getSimpleName();
+    private final Context mContext;
+    private final SmartPreferences mPrefs;
+    private Proxy mProxy;
+    private boolean mEnabled;
+
+    public ProxyManager(Context context) {
+        mContext = context;
+        mPrefs = SmartPreferences.instance(mContext);
+        loadProxyInfoFromPrefs();
+    }
+
+
+    /**
+     * Get the string representation of current proxy settings.
+     * @return String representation of current proxy settings.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    public String getProxyUriString() {
+        if (mProxy == null || mProxy.type() == Proxy.Type.DIRECT) {
+            return "";
+        }
+        else {
+            InetSocketAddress proxyAddr = (InetSocketAddress) mProxy.address();
+            return mProxy.type().name().toLowerCase() + "://" + proxyAddr.getHostString()
+                    + ":" + proxyAddr.getPort();
+        }
+    }
+
+    /**
+     * Check if proxy is enabled in preference settings.
+     * This doesn't reflect the status whether the proxy is in use, use
+     * {@link #isProxyConfigured()} to check if the proxy is effectively configured.
+     * @return True if proxy setting is enabled in preference. Otherwise false.
+     */
+    public boolean isProxyEnabled() {
+        return mEnabled;
+    }
+
+    /**
+     * Check if proxy setting is configured and is being used by app.
+     * @return Whether the proxy is being used, i.e. system properties are configured according to proxy settings.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    public boolean isProxyConfigured() {
+        if (mProxy == null || mProxy.type() == Proxy.Type.DIRECT) {
+            return System.getProperty("http.proxyHost") == null
+                    && System.getProperty("https.proxyHost") == null
+                    && System.getProperty("socksProxyHost") == null;
+        }
+        InetSocketAddress proxyAddr = (InetSocketAddress) mProxy.address();
+        String proxyHost = proxyAddr.getHostString();
+        String proxyPort = Integer.toString(proxyAddr.getPort());
+        switch (mProxy.type()) {
+            case HTTP:
+                return proxyHost.equals(System.getProperty("http.proxyHost"))
+                        && proxyPort.equals(System.getProperty("http.proxyPort"))
+                        && proxyHost.equals(System.getProperty("https.proxyHost"))
+                        && proxyPort.equals(System.getProperty("https.proxyPort"));
+            case SOCKS:
+                return proxyHost.equals(System.getProperty("socksProxyHost"))
+                        && proxyPort.equals(System.getProperty("socksProxyPort"));
+        }
+        return false;
+    }
+
+    public Proxy getCurrentProxy() {
+        return mProxy;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    public String getProxyHost() {
+        return mProxy == null ? "" : ((InetSocketAddress)mProxy.address()).getHostString();
+    }
+
+    public int getProxyPort() {
+        return mProxy == null ? 0 : ((InetSocketAddress)mProxy.address()).getPort();
+    }
+
+    public Proxy.Type getProxyType() {
+        return mProxy == null ? Proxy.Type.DIRECT : mProxy.type();
+    }
+
+    protected void loadProxyInfoFromPrefs() {
+        try {
+            String proxyUriString = mPrefs.getWebProxyUri();
+            Log.d(TAG, "Web Proxy URI from preferences: \""
+                    + proxyUriString + "\"; " + mEnabled);
+            if (proxyUriString.isEmpty() || proxyUriString.equalsIgnoreCase(Proxy.Type.DIRECT.name())) {
+                mProxy = Proxy.NO_PROXY;
+            }
+            else {
+                URI proxyURI = new URI(proxyUriString);
+                mProxy = new Proxy(Proxy.Type.valueOf(proxyURI.getScheme().toUpperCase()),
+                        InetSocketAddress.createUnresolved(proxyURI.getHost(), proxyURI.getPort()));
+            }
+            mEnabled = mPrefs.getWebProxyEnabled();
+        }
+        catch (URISyntaxException e) {
+            Log.e(TAG, e);
+            mProxy = Proxy.NO_PROXY;
+            mEnabled = false; // disable invalid proxy settings.
+        }
+    }
+
+    /**
+     * Save proxy settings to preferences.
+     * This method only save the settings, it doesn't actually configure the system to use the proxy.
+     * Use {@link #configureSystemProxy()} to configure system proxy settings.
+     *
+     * @param proxy Specify new proxy settings, if null, current proxy setting will be saved.
+     * @param enable Set proxy enabled/disabled.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    public void saveProxyInfoToPrefs(Proxy proxy, boolean enable) {
+        if (proxy != null)
+            mProxy = new Proxy(proxy.type(), proxy.address());
+        mEnabled = enable;
+        String proxyUriString = getProxyUriString();
+        mPrefs.setWebProxyUri(proxyUriString);
+        mPrefs.setWebProxyEnabled(mEnabled);
+        String toastMessage = enable ? mContext.getString(R.string.proxy_enabled, proxyUriString)
+                : mContext.getString(R.string.proxy_disabled);
+        MessageHelpers.showLongMessage(mContext, toastMessage);
+        Log.d(TAG, "Saved Web Proxy URI to preferences: "
+                + proxyUriString + "; Enabled: " + mEnabled);
+    }
+
+    /**
+     * Create proxy info object required by {@link android.net.Proxy#PROXY_CHANGE_ACTION} intent.
+     * Before API 21, it is an android.net.ProxyProperties object.
+     * Since API 21, it is an {@link android.net.ProxyInfo} object.
+     *
+     * Note: this may NOT work in future if Android's internal implementation changes.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    protected Object createProxyChangeInfo(InetSocketAddress proxyAddr) throws
+            ClassNotFoundException,
+            NoSuchMethodException,
+            IllegalAccessException,
+            InvocationTargetException,
+            InstantiationException
+    {
+        if (Build.VERSION.SDK_INT < 21) {
+            // https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-4.4.4_r2.0.1/core/java/android/net/ProxyProperties.java#65
+            @SuppressLint("PrivateApi") Class<?> proxyPropClazz = Class.forName("android.net.ProxyProperties");
+            Constructor proxyPropCtor = proxyPropClazz.getDeclaredConstructor(String.class, String.class, String[].class);
+            return proxyPropCtor.newInstance(proxyAddr.getHostString(), Integer.toString(proxyAddr.getPort()), null);
+        }
+        else {
+            return ProxyInfo.buildDirectProxy(proxyAddr.getHostString(), proxyAddr.getPort());
+        }
+    }
+
+    /**
+     * Configure web proxy for the app.
+     *
+     * The implementation is based on:
+     * <a href=https://stackoverflow.com/questions/4488338/webview-android-proxy>this StackOverflow discussion</a>.
+     *
+     * Also refer to Chromium source code of
+     * <a href=https://chromium.googlesource.com/chromium/src/net/+/master/android/java/src/org/chromium/net/ProxyChangeListener.java>ProxyChangeListener.java</a>
+     *
+     * @return true if proxy is successfully enabled/disabled, otherwise false.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    private boolean setWebProxyAPI19Plus() throws
+            NoSuchFieldException,
+            IllegalAccessException,
+            NoSuchMethodException,
+            InstantiationException,
+            InvocationTargetException,
+            ClassNotFoundException
+    {
+        if (BuildConfig.DEBUG && Build.VERSION.SDK_INT < 19) {
+            throw new AssertionError("API level must >= 19");
+        }
+        Proxy proxy = mEnabled && mProxy != null ? mProxy : Proxy.NO_PROXY;
+        Context appContext = mContext.getApplicationContext();
+        InetSocketAddress proxyAddr = (InetSocketAddress) proxy.address();
+        switch (mProxy.type()) {
+            case HTTP:
+                System.setProperty("http.proxyHost", proxyAddr.getHostString());
+                System.setProperty("http.proxyPort", proxyAddr.getPort() + "");
+                System.setProperty("https.proxyHost", proxyAddr.getHostString());
+                System.setProperty("https.proxyPort", proxyAddr.getPort() + "");
+                System.clearProperty("socksProxyHost");
+                System.clearProperty("socksProxyPort");
+                break;
+            case SOCKS:
+                System.setProperty("socksProxyHost", proxyAddr.getHostString());
+                System.setProperty("socksProxyPort", proxyAddr.getPort() + "");
+                System.clearProperty("http.proxyHost");
+                System.clearProperty("http.proxyPort");
+                System.clearProperty("https.proxyHost");
+                System.clearProperty("https.proxyPort");
+                break;
+            case DIRECT:
+                System.clearProperty("socksProxyHost");
+                System.clearProperty("socksProxyPort");
+                System.clearProperty("http.proxyHost");
+                System.clearProperty("http.proxyPort");
+                System.clearProperty("https.proxyHost");
+                System.clearProperty("https.proxyPort");
+                break;
+        }
+        Field loadedApkField = appContext.getClass().getField("mLoadedApk");
+        loadedApkField.setAccessible(true);
+        Object loadedApk = loadedApkField.get(appContext);
+        @SuppressLint("PrivateApi") Class<?> loadedApkCls = Class.forName("android.app.LoadedApk");
+        Field receiversField = loadedApkCls.getDeclaredField("mReceivers");
+        receiversField.setAccessible(true);
+        ArrayMap receivers = (ArrayMap) receiversField.get(loadedApk);
+        for (Object receiverMap : receivers.values()) {
+            for (Object rec : ((ArrayMap) receiverMap).keySet()) {
+                Class<? extends Object> clazz = rec.getClass();
+                if (clazz.getName().contains("ProxyChangeListener")) {
+                    Method onReceiveMethod = clazz.getDeclaredMethod("onReceive", Context.class, Intent.class);
+                    Intent intent = new Intent(android.net.Proxy.PROXY_CHANGE_ACTION);
+                    Object proxyInfo = createProxyChangeInfo(proxyAddr);
+                    intent.putExtra("android.intent.extra.PROXY_INFO", (Parcelable) proxyInfo);
+                    onReceiveMethod.invoke(rec, appContext, intent);
+                }
+            }
+        }
+        Log.d(TAG, "Web Proxy set to: " + getProxyUriString());
+        return true;
+    }
+
+    public boolean configureSystemProxy() {
+        try {
+            if (Build.VERSION.SDK_INT < 19) {
+                throw new UnsupportedOperationException("Web Proxy support not implemented for API level < 19");
+            }
+            else { // API level >= 19
+                return setWebProxyAPI19Plus();
+            }
+        } catch (Exception e) {
+            Log.e(TAG, e);
+            return false;
+        }
+    }
+}

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv/prefs/SmartPreferences.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv/prefs/SmartPreferences.java
@@ -72,6 +72,8 @@ public final class SmartPreferences extends SmartPreferencesBase {
     public static final String VIDEO_TYPE_DEFAULT = "video_type_default";
     public static final String VIDEO_TYPE_LIVE = "video_type_live";
     public static final String VIDEO_TYPE_UPCOMING = "video_type_upcoming";
+    public static final String WEB_PROXY_URI = "web_proxy_url";
+    public static final String WEB_PROXY_ENABLED = "web_proxy_enabled";
     public static final int PLAYBACK_UNKNOWN = 0;
     public static final int PLAYBACK_IS_WORKING = 1;
     public static final int PLAYBACK_NOT_WORKING = 2;
@@ -561,4 +563,12 @@ public final class SmartPreferences extends SmartPreferencesBase {
     public void setEnableAnimatedUI(boolean enable) {
         putBoolean(ENABLE_ANIMATED_UI, enable);
     }
+
+    public String getWebProxyUri() { return getString(WEB_PROXY_URI, ""); }
+
+    public void setWebProxyUri(String webProxy) { putString(WEB_PROXY_URI, webProxy); }
+
+    public boolean getWebProxyEnabled() { return getBoolean(WEB_PROXY_ENABLED, false); }
+
+    public void setWebProxyEnabled(boolean enable) { putBoolean(WEB_PROXY_ENABLED, enable);}
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="system_lang">Default</string>
     <string name="log_stored_in_path">Log enabled: %s</string>
     <string name="log_to_file_started">Starting log: %s</string>
+    <string name="proxy_enabled">Web Proxy Enabled: %s</string>
+    <string name="proxy_disabled">Web Proxy Disabled</string>
 </resources>

--- a/smartyoutubetv/src/main/java/com/liskovsoft/smartyoutubetv/bootstrap/dialogtweaks/TweaksDialogSource.java
+++ b/smartyoutubetv/src/main/java/com/liskovsoft/smartyoutubetv/bootstrap/dialogtweaks/TweaksDialogSource.java
@@ -37,6 +37,7 @@ import com.liskovsoft.smartyoutubetv.bootstrap.dialogtweaks.items.UpdateCheckDia
 import com.liskovsoft.smartyoutubetv.bootstrap.dialogtweaks.items.ProUseExternalPlayer4KDialogItem;
 import com.liskovsoft.smartyoutubetv.bootstrap.dialogtweaks.items.ProUseExternalPlayerFHDDialogItem;
 import com.liskovsoft.smartyoutubetv.bootstrap.dialogtweaks.items.ProUseExternalPlayerSDDialogItem;
+import com.liskovsoft.smartyoutubetv.bootstrap.dialogtweaks.items.WebProxyDialogItem;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,6 +91,7 @@ public class TweaksDialogSource implements MultiDialogSource {
         mItems.add(new ATVPublishHistoryDialogItem(mContext));
         mItems.add(new ATVPublishRecommendedDialogItem(mContext));
         mItems.add(new ATVPublishSubscriptionsDialogItem(mContext));
+        mItems.add(new WebProxyDialogItem(mContext));
     }
 
     @Override

--- a/smartyoutubetv/src/main/java/com/liskovsoft/smartyoutubetv/bootstrap/dialogtweaks/items/WebProxyDialogItem.java
+++ b/smartyoutubetv/src/main/java/com/liskovsoft/smartyoutubetv/bootstrap/dialogtweaks/items/WebProxyDialogItem.java
@@ -1,0 +1,204 @@
+package com.liskovsoft.smartyoutubetv.bootstrap.dialogtweaks.items;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.RadioGroup;
+import android.widget.TextView;
+
+import com.liskovsoft.sharedutils.dialogs.GenericSelectorDialog.DialogSourceBase.DialogItem;
+import com.liskovsoft.sharedutils.mylogger.Log;
+import com.liskovsoft.sharedutils.okhttp.OkHttpHelpers;
+import com.liskovsoft.smartyoutubetv.R;
+import com.liskovsoft.smartyoutubetv.misc.ProxyManager;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.ArrayList;
+
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AlertDialog;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class WebProxyDialogItem extends DialogItem {
+    public static final String TAG = WebProxyDialogItem.class.getSimpleName();
+    private final Context mContext;
+    private AlertDialog mProxyConfigDialog;
+    private final ProxyManager mProxyManager;
+    private final Handler mProxyTestHandler;
+    private final ArrayList<Call> mUrlTests;
+    private int mNumTests;
+
+    public WebProxyDialogItem(Context context) {
+        super(context.getString(Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
+                ? R.string.enable_web_proxy : R.string.proxy_not_supported), false);
+
+        mContext = context;
+        mProxyManager = new ProxyManager(mContext);
+        mProxyTestHandler = new Handler(Looper.myLooper());
+        mUrlTests = new ArrayList<>();
+    }
+
+    @Override
+    public boolean getChecked() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            return mProxyManager.isProxyEnabled();
+        }
+        else {
+            return false;
+        }
+    }
+
+    @Override
+    public void setChecked(boolean checked) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            mProxyManager.saveProxyInfoToPrefs(null, checked);
+            if (checked)
+                // FIXME: If user hit cancel in dialog, proxy remains enabled.
+                showProxyConfigDialog();
+        }
+    }
+
+    protected void appendStatusMessage(String msgFormat, Object ...args) {
+        TextView statusView = mProxyConfigDialog.findViewById(R.id.proxy_config_message);
+        String message = String.format(msgFormat, args);
+        if (statusView.getText().toString().isEmpty())
+            statusView.append(message);
+        else
+            statusView.append("\n"+message);
+    }
+
+    protected void appendStatusMessage(int resId, Object ...args) {
+        appendStatusMessage(mContext.getString(resId), args);
+    }
+
+    protected Proxy validateProxyConfigFields() {
+        boolean isConfigValid = true;
+        int proxyTypeId = ((RadioGroup) mProxyConfigDialog.findViewById(R.id.proxy_type)).getCheckedRadioButtonId();
+        if (proxyTypeId == -1) {
+            isConfigValid = false;
+            appendStatusMessage(R.string.proxy_type_invalid);
+            mProxyConfigDialog.findViewById(R.id.proxy_type_http).requestFocus();
+        }
+        String proxyHost = ((EditText) mProxyConfigDialog.findViewById(R.id.proxy_host)).getText().toString();
+        if (proxyHost.isEmpty()) {
+            isConfigValid = false;
+            appendStatusMessage(R.string.proxy_host_invalid);
+        }
+        String proxyPortString = ((EditText) mProxyConfigDialog.findViewById(R.id.proxy_port)).getText().toString();
+        int proxyPort = proxyPortString.isEmpty() ? 0 : Integer.parseInt(proxyPortString);
+        if (proxyPort <= 0) {
+            isConfigValid = false;
+            appendStatusMessage(R.string.proxy_port_invalid);
+        }
+        if (!isConfigValid) {
+            return null;
+        }
+        Proxy.Type proxyType = proxyTypeId == R.id.proxy_type_http ? Proxy.Type.HTTP : Proxy.Type.SOCKS;
+        return new Proxy(proxyType, InetSocketAddress.createUnresolved(proxyHost, proxyPort));
+    }
+
+    protected void testProxyConnections() {
+        Proxy proxy = validateProxyConfigFields();
+        if (proxy == null) {
+            appendStatusMessage(R.string.proxy_test_aborted);
+            return;
+        }
+
+        String[] testUrls = mContext.getString(R.string.proxy_test_urls).split("\n");
+        OkHttpClient okHttpClient = OkHttpHelpers.createOkHttpClient();
+
+        for (String urlString: testUrls) {
+            int serialNo = ++ mNumTests;
+            Request request = new Request.Builder().url(urlString).build();
+            appendStatusMessage(R.string.proxy_test_start, serialNo, urlString);
+            Call call = okHttpClient.newCall(request);
+            call.enqueue(new Callback() {
+                @Override
+                public void onFailure(Call call, IOException e) {
+                    if (call.isCanceled())
+                        mProxyTestHandler.post(() -> appendStatusMessage(R.string.proxy_test_cancelled, serialNo));
+                    else
+                        mProxyTestHandler.post(() -> appendStatusMessage(R.string.proxy_test_error, serialNo, e));
+                }
+
+                @Override
+                public void onResponse(Call call, Response response) {
+                    String protocol = response.protocol().toString().toUpperCase();
+                    int code = response.code();
+                    String status = response.message();
+                    mProxyTestHandler.post(() -> appendStatusMessage(R.string.proxy_test_status,
+                            serialNo, protocol, code, status.isEmpty() ? "OK" : status));
+                }
+            });
+            mUrlTests.add(call);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    protected void showProxyConfigDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(mContext);
+        LayoutInflater inflater = LayoutInflater.from(mContext);
+        View contentView = inflater.inflate(R.layout.web_proxy_config, null);
+
+        if (mProxyManager.getProxyType() == Proxy.Type.DIRECT) {
+            ((EditText) contentView.findViewById(R.id.proxy_host)).setText("");
+            ((EditText) contentView.findViewById(R.id.proxy_port)).setText("");
+            ((RadioGroup) contentView.findViewById(R.id.proxy_type)).clearCheck();
+        }
+        else {
+            ((EditText) contentView.findViewById(R.id.proxy_host)).setText(mProxyManager.getProxyHost());
+            ((EditText) contentView.findViewById(R.id.proxy_port)).setText(String.valueOf(mProxyManager.getProxyPort()));
+            int proxyTypeId = mProxyManager.getProxyType() == Proxy.Type.HTTP ? R.id.proxy_type_http : R.id.proxy_type_socks;
+            ((RadioGroup) contentView.findViewById(R.id.proxy_type)).check(proxyTypeId);
+        }
+
+        // keep empty, will override below.
+        // https://stackoverflow.com/a/15619098/5379584
+        mProxyConfigDialog = builder
+                .setTitle(R.string.proxy_settings_title)
+                .setView(contentView)
+                .setNeutralButton(R.string.proxy_test_btn, (dialog, which) -> { })
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> { })
+                .setNegativeButton(android.R.string.cancel, (dialog, which) -> { })
+                .create();
+
+        mNumTests = 0;
+        mProxyConfigDialog.show();
+
+        mProxyConfigDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener((view) -> {
+            ((TextView) mProxyConfigDialog.findViewById(R.id.proxy_config_message)).setText("");
+            Proxy proxy = validateProxyConfigFields();
+            if (proxy == null) {
+                appendStatusMessage("Please correct proxy settings first.");
+            }
+            else {
+                Log.d(TAG, "Saving proxy info: " + proxy);
+                mProxyManager.saveProxyInfoToPrefs(proxy, true);
+                for (Call call: mUrlTests) call.cancel();
+                mProxyConfigDialog.dismiss();
+            }
+        });
+
+        mProxyConfigDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener((view) -> {
+            for (Call call: mUrlTests) call.cancel();
+            mUrlTests.clear();
+            ((TextView) mProxyConfigDialog.findViewById(R.id.proxy_config_message)).setText("");
+            testProxyConnections();
+        });
+
+        mProxyConfigDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener((view) -> {
+            for (Call call: mUrlTests) call.cancel();
+            mProxyConfigDialog.dismiss();
+        });
+    }
+}

--- a/smartyoutubetv/src/main/res/layout/web_proxy_config.xml
+++ b/smartyoutubetv/src/main/res/layout/web_proxy_config.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/web_proxy_config"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="10sp">
+
+    <EditText
+        android:id="@+id/proxy_host"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autofillHints=""
+        android:ems="10"
+        android:hint="@string/proxy_host_hint"
+        android:imeOptions="actionNext"
+        android:inputType="textUri|textPersonName"
+        android:textColor="@color/white"
+        android:textColorHint="@color/white_50" />
+
+    <EditText
+        android:id="@+id/proxy_port"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:autofillHints=""
+        android:ems="10"
+        android:hint="@string/proxy_port_hint"
+        android:imeOptions="actionDone"
+        android:inputType="number"
+        android:textColor="@color/white"
+        android:textColorHint="@color/white_50" />
+
+    <TextView
+        android:id="@+id/proxy_type_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:text="@string/proxy_type"
+        android:textColor="@color/sub_text_color2"
+        android:textSize="18sp" />
+
+    <RadioGroup
+        android:id="@+id/proxy_type"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <RadioButton
+            android:id="@+id/proxy_type_http"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/proxy_type_http"
+            android:textColor="@color/white" />
+
+        <RadioButton
+            android:id="@+id/proxy_type_socks"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/proxy_type_socks"
+            android:textColor="@color/white" />
+    </RadioGroup>
+
+    <TextView
+        android:id="@+id/proxy_config_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:lines="4"
+        android:textColor="@color/sub_text_color" />
+</LinearLayout>

--- a/smartyoutubetv/src/main/res/values/strings.xml
+++ b/smartyoutubetv/src/main/res/values/strings.xml
@@ -121,4 +121,22 @@
     <string name="tweak_hold_ok_video_menu">Hold OK for video menu (impact performance)</string>
     <string name="tweak_animated_ui">Animated UI (impact performance)</string>
     <string name="tweak_ok_pause_without_ui">OK pauses video immediately (without UI)</string>
+    <string name="proxy_port_hint">Proxy Port</string>
+    <string name="proxy_host_hint">Proxy hostname or IP</string>
+    <string name="proxy_type">Proxy Type</string>
+    <string name="proxy_type_http">HTTP</string>
+    <string name="proxy_type_socks">SOCKS</string>
+    <string name="enable_web_proxy">Use Web Proxy</string>
+    <string name="proxy_not_supported">Use Web Proxy (Needs Android 4.4+)</string>
+    <string name="proxy_test_btn">Test</string>
+    <string name="proxy_settings_title">Proxy Server Settings</string>
+    <string name="proxy_test_urls">https://www.youtube.com\nhttps://www.google.com</string>
+    <string name="proxy_test_cancelled">Test#%d: cancelled.</string>
+    <string name="proxy_type_invalid">Proxy type not set.</string>
+    <string name="proxy_host_invalid">Proxy host not set.</string>
+    <string name="proxy_port_invalid">Invalid proxy port, must &gt; 0.></string>
+    <string name="proxy_test_aborted">Test aborted, please fix proxy settings first.</string>
+    <string name="proxy_test_start">Test#%d: %s ...</string>
+    <string name="proxy_test_error">Error#%d: %s</string>
+    <string name="proxy_test_status">Status#%d: %s %d %s</string>
 </resources>


### PR DESCRIPTION
Attempt to support HTTP/SOCKS proxies.

Solve the problem where Youtube and/or Google sites are blocked (particularly in some countries). 
Such problems has been reported e.g. issue #95, and similar feature has been requested by users. e.g. issue #177.
This is useful as many Android TV don't provide user interface to configure a proxy for customer.

The solutions involves 3 parts:
1. Introduces new preference keys `web_proxy_url` and `web_proxy_enabled` to `class SmartPreferences` to save proxy settings.
2. Added new UI `class WebProxyDialogItem` to change proxy settings.
3. Finally, added `class ProxyManager` to start/stop proxy.

Limitation to current implementation:
* So far only supports Android 4.4+.
* UI style might need some tweak to be consistent with the rest of the app.